### PR TITLE
Update flagship-for-woocommerce.php

### DIFF
--- a/flagship-for-woocommerce.php
+++ b/flagship-for-woocommerce.php
@@ -78,7 +78,7 @@ function display_tracking_details($order){
         $url = 'https://www.dicom.com/en/express/tracking/load-tracking/'.$trackingNumber.'?division=DicomExpress';
     }
 
-    echo '<p><a target="_blank" href="'.$url .'">Track Your Order Here</a></p>';
+    if(strlen($trackingNumber)) { echo '<p><a target="_blank" href="'.$url .'">Track Your Order Here</a></p>'; }
 
 }
 


### PR DESCRIPTION
Remove Track Your Order Here if their is no tracking number associated with the order. Ex: when another shipping method is used (not flagship) (sorry for my english ;-) )